### PR TITLE
fix: only redirect server logs to sdtout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ RUN addgroup --gid 1001 --system unifi && \
     curl -SsfL "https://www.ubnt.com/downloads/unifi/${UNIFI_VERSION}/UniFi.unix.zip" | \
         bsdtar -xf - -C /opt/app/unifi -X /.tarignore --strip-components=1 && \
     chown -R unifi:unifi /opt/app/unifi && \
+    ln -sf /dev/stdout /opt/app/unifi/logs/server.log && \
+    ln -sf /dev/null /opt/app/unifi/logs/tasks.log && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/*
 

--- a/overlay/etc/templates/system.properties.tmpl
+++ b/overlay/etc/templates/system.properties.tmpl
@@ -1,5 +1,5 @@
 ## system.properties
-unifi.logStdout=true
+unifi.logStdout=false
 
 db.mongo.local=false
 db.mongo.uri=PLACEHOLDER

--- a/overlay/usr/bin/entrypoint
+++ b/overlay/usr/bin/entrypoint
@@ -20,7 +20,7 @@ set_conf_value() {
     log_info "Appending option '${thekey}' as not found"
     log_info "$thekey=$newvalue" >>$filename
   else
-    log_info "Skipping option '${thekey}' as found already"
+    log_info "Ensure value for option '${thekey}'"
     sed -ir "s,^[#]*\s*${thekey}=.*,$thekey=$newvalue," $filename
   fi
 }
@@ -34,7 +34,7 @@ else
   cp /etc/templates/system.properties.tmpl ${DATADIR}/system.properties
 fi
 
-set_conf_value "unifi.logStdout" "true"
+set_conf_value "unifi.logStdout" "false"
 set_conf_value "db.mongo.local" "false"
 set_conf_value "db.mongo.uri" "$MONGOURL"
 set_conf_value "statdb.mongo.uri" "$MONGOSTATURL"


### PR DESCRIPTION
- redirect server log to `stdout`
- redirect tasks log to `/dev/null` due to high freq debug spam

```
[2023-10-13 12:18:10,412] <ble_state_check> DEBUG tasks  - Started task[ble_state_check]
[2023-10-13 12:18:10,413] <ble_state_check> DEBUG tasks  - Finished task[ble_state_check] in 1 ms
[2023-10-13 12:18:10,499] <tracer> DEBUG tasks  - Started task[tracer]
[2023-10-13 12:18:10,499] <tracer> DEBUG tasks  - Finished task[tracer] in 0 ms
[2023-10-13 12:18:15,030] <device-state-check> DEBUG tasks  - Started task[device-state-check]
[2023-10-13 12:18:15,033] <device-state-check> DEBUG tasks  - Finished task[device-state-check] in 3 ms
[2023-10-13 12:18:15,414] <ble_state_check> DEBUG tasks  - Started task[ble_state_check]
[2023-10-13 12:18:15,414] <ble_state_check> DEBUG tasks  - Finished task[ble_state_check] in 0 ms
[2023-10-13 12:18:15,421] <stamgr> DEBUG tasks  - Started task[stamgr]
[2023-10-13 12:18:15,422] <stamgr> DEBUG tasks  - Finished task[stamgr] in 1 ms
[2023-10-13 12:18:15,422] <wss-connection> DEBUG tasks  - Started task[wss-connection]
[2023-10-13 12:18:15,422] <wss-connection> DEBUG tasks  - Finished task[wss-connection] in 0 ms
[2023-10-13 12:18:15,500] <tracer> DEBUG tasks  - Started task[tracer]
[2023-10-13 12:18:15,500] <tracer> DEBUG tasks  - Finished task[tracer] in 0 ms
[2023-10-13 12:18:15,501] <webrtc-connection> DEBUG tasks  - Started task[webrtc-connection]
[2023-10-13 12:18:15,501] <webrtc-connection> DEBUG tasks  - Finished task[webrtc-connection] in 0 ms
```